### PR TITLE
chore(web): drop unused react dnd test backend

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,6 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "jsdom": "^22.1.0",
-    "@react-dnd/test-backend": "^16.0.1",
     "eslint": "^8.46.0",
     "eslint-plugin-react": "^7.33.2",
     "prettier": "^3.0.0"


### PR DESCRIPTION
## Summary
- remove @react-dnd/test-backend from web devDependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hookform%2fresolvers)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `docker compose build web` *(fails: bash: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689a747b23188332a8648488a4e004da