### PR TITLE
chore(web): install dev dependencies in Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,5 +2,6 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package.json tsconfig.json vite.config.ts tailwind.config.js postcss.config.js index.html ./
 COPY src ./src
+ENV NODE_ENV=development
 RUN npm install
 CMD ["npm","run","dev"]


### PR DESCRIPTION
## Summary
- ensure web image installs dev dependencies by setting `NODE_ENV=development`

## Testing
- `npm install --include=dev`
- `npm test` *(fails: Cannot find module 'autoprefixer')*
- `docker-compose build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8538cf6483329b4466b89d8384ab