### PR TITLE
Set PYTHONPATH for API service

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
+ENV PYTHONPATH=/app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .


### PR DESCRIPTION
## Summary
- add PYTHONPATH environment variable to API Dockerfile so Alembic can locate `app`

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_689a858f60508332b7bb24e17a3919aa