### PR TITLE
docs: clarify migrations in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ To bring up the full stack with the database migrated and seeded, run:
 docker-compose up --build
 ```
 
+This builds and starts every service. During startup, the `api-migrate` service
+executes `alembic upgrade head` so all database migrations are applied before
+the API container begins serving requests.
+
+To apply migrations manually without bringing up the full stack, run:
+
+```
+docker compose run --rm api alembic upgrade head
+```
+This is the same command executed by the `make migrate` shortcut shown below.
+
 ```
 make dev       # build and run containers
 make migrate   # run alembic migrations


### PR DESCRIPTION
## Summary
- note that `docker-compose up --build` runs the `api-migrate` service to apply database migrations before starting the API
- document a command to run migrations manually

## Testing
- `make test` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b197bc08332ba99d01ca6a0caf9