### PR TITLE
Use pydantic-settings for configuration and update dependencies

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from typing import List
 
 class Settings(BaseSettings):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 sqlalchemy[asyncio]
 alembic
 pydantic
+pydantic-settings
 python-multipart
 passlib[bcrypt]
 python-jose


### PR DESCRIPTION
## Summary
- switch configuration to use `BaseSettings` from `pydantic-settings`
- add `pydantic-settings` to API requirements

## Testing
- `docker compose up --build` *(failed: command not found: docker)*
- `apt-get update` *(failed: repository signatures, 403 Forbidden)*
- `python -m pip install -r api/requirements.txt` *(failed: tunnel connection failed: 403 Forbidden)*
- `pytest` *(failed: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_689a94ad03d88332be8df2efe3adc3ac