### PR TITLE
Preserve web node_modules volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       VITE_API_URL: http://localhost:8000
     volumes:
       - ./web:/app
+      - /app/node_modules
     ports:
       - '5173:5173'
     depends_on:


### PR DESCRIPTION
## Summary
- Mount anonymous /app/node_modules volume for web service to keep dependencies inside container

## Testing
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a99aabfe083329bb0e4937a0d2d28