### PR TITLE
Use JSON array for CORS origins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       DB_URL: postgresql+psycopg2://clack:clack@db:5432/clack
       JWT_SECRET: change-me
-      CORS_ORIGINS: http://localhost:5173
+      CORS_ORIGINS: '["http://localhost:5173"]'
       UPLOAD_DIR: /app/uploads
     volumes:
       - ./api:/app
@@ -29,7 +29,7 @@ services:
     environment:
       DB_URL: postgresql+psycopg2://clack:clack@db:5432/clack
       JWT_SECRET: change-me
-      CORS_ORIGINS: http://localhost:5173
+      CORS_ORIGINS: '["http://localhost:5173"]'
       UPLOAD_DIR: /app/uploads
     volumes:
       - ./api:/app


### PR DESCRIPTION
## Summary
- ensure CORS_ORIGINS is passed as a JSON array in docker-compose to satisfy Pydantic parsing

## Testing
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*
- `npm test` *(fails: Cannot find module 'autoprefixer')*

------
https://chatgpt.com/codex/tasks/task_e_689aa490caa883329de26da6e1176c47