### PR TITLE
chore(web): add autoprefixer dev dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "jsdom": "^22.1.0",
     "eslint": "^8.46.0",
     "eslint-plugin-react": "^7.33.2",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "autoprefixer": "^10.4.14"
   }
 }


### PR DESCRIPTION
## Summary
- add `autoprefixer` to web's devDependencies per Tailwind setup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: Cannot find module 'autoprefixer')*


------
https://chatgpt.com/codex/tasks/task_e_689aa5914c1c83328759d886efefff04