### PR TITLE
Add email-validator dependency

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 sqlalchemy[asyncio]
 alembic
 pydantic
+email-validator
 pydantic-settings
 python-multipart
 passlib[bcrypt]


### PR DESCRIPTION
## Summary
- add email-validator to API dependencies for EmailStr support

## Testing
- `pip install -r api/requirements.txt` *(fails: Could not find a version that satisfies the requirement email-validator)*
- `docker compose build api` *(fails: command not found)*
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*
- `uvicorn app.main:app --host 0.0.0.0 --port 8000` *(fails: ImportError: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b239372288332b2aaed817289e74e